### PR TITLE
Create Store model with Mongoose

### DIFF
--- a/spar-med-samvittighed/models/store.ts
+++ b/spar-med-samvittighed/models/store.ts
@@ -1,0 +1,22 @@
+import { Schema, model } from 'mongoose';
+
+// Define the User interface (for type safety)
+interface Store {
+    brand: 'bilka' | 'foetex' | 'netto';
+    name: string;
+  }  
+
+  const StoreSchema = new Schema<Store>({
+    brand: {
+        type: String,
+        required: [true, 'Brand is required!'],
+        enum: ['bilka', 'foetex', 'netto'], 
+    },
+    name: {
+      type: String,
+      unique: true,
+      required: [true, 'Name is required!'],
+    },
+  });
+    
+export const Store = model<Store>('Store', StoreSchema);


### PR DESCRIPTION
- Define the Store interface for type safety
- Set up the Mongoose schema for the Store model
- Define the brand field with an enum of 'bilka', 'foetex', or 'netto'
- Define the name field with a unique and required constraint
- Export the Store model for use in other modules