### PR TITLE
"Add regex validation for brand and name in Store model"

### DIFF
--- a/spar-med-samvittighed/models/store.ts
+++ b/spar-med-samvittighed/models/store.ts
@@ -11,11 +11,13 @@ interface Store {
         type: String,
         required: [true, 'Brand is required!'],
         enum: ['bilka', 'foetex', 'netto'], 
+        match: /^(bilka|foetex|netto)$/
     },
     name: {
       type: String,
       unique: true,
       required: [true, 'Name is required!'],
+      match: /^[a-zA-Z0-9\-_]+$/
     },
   });
     


### PR DESCRIPTION
This diff adds regex pattern matching to the 'brand' and 'name' fields in the Store model. The 'brand' field now only accepts 'bilka', 'foet